### PR TITLE
test: replace deprecated @covers doc-comments with PHP attributes

### DIFF
--- a/tests/DatabaseServiceProviderTest.php
+++ b/tests/DatabaseServiceProviderTest.php
@@ -10,11 +10,10 @@ use JoeriAbbo\LaravelPrometheusExporter\PrometheusExporter;
 use JoeriAbbo\LaravelPrometheusExporter\PrometheusServiceProvider;
 use JoeriAbbo\LaravelPrometheusExporter\Tests\Fixture\MetricSamplesSpec;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prometheus\Histogram;
 
-/**
- * @covers \JoeriAbbo\LaravelPrometheusExporter\DatabaseServiceProvider<extended>
- */
+#[CoversClass(\JoeriAbbo\LaravelPrometheusExporter\DatabaseServiceProvider::class)]
 class DatabaseServiceProviderTest extends TestCase
 {
     private $createdTable = false;

--- a/tests/GuzzleServiceProviderTest.php
+++ b/tests/GuzzleServiceProviderTest.php
@@ -13,11 +13,10 @@ use JoeriAbbo\LaravelPrometheusExporter\GuzzleMiddleware;
 use JoeriAbbo\LaravelPrometheusExporter\GuzzleServiceProvider;
 use JoeriAbbo\LaravelPrometheusExporter\PrometheusServiceProvider;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prometheus\Histogram;
 
-/**
- * @covers \JoeriAbbo\LaravelPrometheusExporter\GuzzleServiceProvider<extended>
- */
+#[CoversClass(\JoeriAbbo\LaravelPrometheusExporter\GuzzleServiceProvider::class)]
 class GuzzleServiceProviderTest extends TestCase
 {
     public function testServiceProvidersShouldHaveCorrectClasses(): void

--- a/tests/MetricsControllerTest.php
+++ b/tests/MetricsControllerTest.php
@@ -9,12 +9,11 @@ use Illuminate\Routing\ResponseFactory;
 use JoeriAbbo\LaravelPrometheusExporter\MetricsController;
 use JoeriAbbo\LaravelPrometheusExporter\PrometheusExporter;
 use Mockery;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Prometheus\RenderTextFormat;
 
-/**
- * @covers \JoeriAbbo\LaravelPrometheusExporter\MetricsController<extended>
- */
+#[CoversClass(\JoeriAbbo\LaravelPrometheusExporter\MetricsController::class)]
 class MetricsControllerTest extends TestCase
 {
     /**

--- a/tests/PrometheusServiceProviderTest.php
+++ b/tests/PrometheusServiceProviderTest.php
@@ -8,11 +8,10 @@ use JoeriAbbo\LaravelPrometheusExporter\PrometheusExporter;
 use JoeriAbbo\LaravelPrometheusExporter\PrometheusServiceProvider;
 use JoeriAbbo\LaravelPrometheusExporter\StorageAdapterFactory;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prometheus\Storage\Adapter;
 
-/**
- * @covers \JoeriAbbo\LaravelPrometheusExporter\PrometheusServiceProvider<extended>
- */
+#[CoversClass(\JoeriAbbo\LaravelPrometheusExporter\PrometheusServiceProvider::class)]
 class PrometheusServiceProviderTest extends TestCase
 {
     public function testServiceProvider(): void

--- a/tests/StorageAdapterFactoryTest.php
+++ b/tests/StorageAdapterFactoryTest.php
@@ -6,14 +6,13 @@ namespace JoeriAbbo\LaravelPrometheusExporter\Tests;
 
 use InvalidArgumentException;
 use JoeriAbbo\LaravelPrometheusExporter\StorageAdapterFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Prometheus\Exception\StorageException;
 use Prometheus\Storage\APC;
 use Prometheus\Storage\InMemory;
 
-/**
- * @covers \JoeriAbbo\LaravelPrometheusExporter\StorageAdapterFactory<extended>
- */
+#[CoversClass(\JoeriAbbo\LaravelPrometheusExporter\StorageAdapterFactory::class)]
 class StorageAdapterFactoryTest extends TestCase
 {
     /**


### PR DESCRIPTION
## Summary

- Converts `@covers ClassName<extended>` doc-comment annotations to `#[CoversClass(ClassName::class)]` PHP attributes in 5 test classes
- Fixes 5 PHPUnit deprecation warnings about metadata in doc-comments
- Prepares codebase for PHPUnit 12 compatibility (doc-comment metadata will be removed)

## Test plan

- [x] All 28 tests pass with `OK (28 tests, 98 assertions)` — no deprecations

🤖 Generated with [Claude Code](https://claude.com/claude-code)